### PR TITLE
Tracer: Adding lock to make it threadsafe

### DIFF
--- a/include/dynamic-graph/tracer.h
+++ b/include/dynamic-graph/tracer.h
@@ -8,6 +8,7 @@
 #include <boost/function.hpp>
 #include <list>
 #include <string>
+#include <mutex>
 
 #include <dynamic-graph/entity.h>
 #include <dynamic-graph/exception-traces.h>
@@ -27,6 +28,7 @@ class DG_TRACER_DLLAPI Tracer : public Entity {
 protected:
   typedef std::list<const SignalBase<int> *> SignalList;
   SignalList toTraceSignals;
+  std::mutex files_mtx;
 
 public:
   enum TraceStyle {

--- a/src/traces/tracer-real-time.cpp
+++ b/src/traces/tracer-real-time.cpp
@@ -146,6 +146,7 @@ void TracerRealTime::openFile(const SignalBase<int> &sig,
 
 void TracerRealTime::closeFiles() {
   dgDEBUGIN(15);
+  std::lock_guard<std::mutex> files_lock(files_mtx);
 
   FileList::iterator iter = files.begin();
   HardFileList::iterator hardIter = hardFiles.begin();


### PR DESCRIPTION
With the existing code we ran into a threading problem. It sometimes happened that the Tracer was stopped and the files closed while still the record() function tried to write to the files. This can happen when using multiple threads (like one thread for the main control and another for python).

The following patch makes sure the `play` variable is locked. This ensures during the `Tracer::record()` call, that the files cannot be closed when using the sequence `tracer.stop(); tracer.close()` from python.